### PR TITLE
Mirror of cloudfoundry uaa#979

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
@@ -58,6 +58,13 @@ public class IdentityZoneResolvingFilter extends OncePerRequestFilter implements
             }
         }
         if (identityZone == null) {
+            // skip filter to static resources in order to serve images and css in case of invalid zones
+            boolean isStaticResource = request.getRequestURI().startsWith("/uaa/resources/");
+            if(isStaticResource) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             request.setAttribute("error_message_code", "zone.not.found");
             response.sendError(HttpServletResponse.SC_NOT_FOUND, "Cannot find identity zone for subdomain " + subdomain);
             return;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
@@ -84,6 +84,7 @@ public class IdentityZoneResolvingFilterTests extends JdbcTestBase {
         String uaaHostname = "uaa.mycf.com";
         String incomingHostname = incomingSubdomain+"."+uaaHostname;
         request.setServerName(incomingHostname);
+        request.setRequestURI("/uaa/login.html");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         FilterChain chain = Mockito.mock(FilterChain.class);
@@ -95,6 +96,33 @@ public class IdentityZoneResolvingFilterTests extends JdbcTestBase {
         assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
         assertEquals(IdentityZone.getUaa(), IdentityZoneHolder.get());
         Mockito.verifyZeroInteractions(chain);
+    }
+
+    @Test
+    public void serveStaticContent_InCase_RetrievingZoneFails() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String incomingSubdomain = "not_a_zone";
+        String uaaHostname = "uaa.mycf.com";
+        String incomingHostname = incomingSubdomain+"."+uaaHostname;
+        request.setServerName(incomingHostname);
+        request.setRequestURI("/uaa/resources/css/application.css");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        MockFilterChain filterChain = new MockFilterChain() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+                assertNotNull(IdentityZoneHolder.get());
+                wasFilterExecuted = true;
+            }
+        };
+        IdentityZoneResolvingFilter filter = new IdentityZoneResolvingFilter();
+        filter.setIdentityZoneProvisioning(dao);
+        filter.setAdditionalInternalHostnames(new HashSet<>(Arrays.asList(uaaHostname)));
+        filter.doFilter(request, response, filterChain);
+
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertTrue(wasFilterExecuted);
+        assertEquals(IdentityZone.getUaa(), IdentityZoneHolder.get());
     }
 
     private void assertFindsCorrectSubdomain(final String subDomainInput, final String incomingHostname, String... additionalInternalHostnames) throws ServletException, IOException {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/IdentityZoneNotAvailableIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/IdentityZoneNotAvailableIT.java
@@ -173,6 +173,15 @@ public class IdentityZoneNotAvailableIT {
         checkNotFoundForEndpoint(HttpMethod.POST,zoneUrl + "/password_resets");
     }
 
+    @Test
+    public void testStaticContentFound() {
+        HttpMethod method  = HttpMethod.GET;
+        String endpoint  = zoneUrl + "/resources/oss/stylesheets/application.css";
+
+        ResponseEntity<Void> forEntity = restTemplate.exchange(endpoint, method, new HttpEntity<Void>(null, new HttpHeaders()), Void.class);
+        assertEquals(HttpStatus.OK, forEntity.getStatusCode());
+    }
+
     private void checkNotFoundForEndpoint(HttpMethod method, String endpoint) {
         ResponseEntity<Void> forEntity = restTemplate.exchange(endpoint, method, new HttpEntity<Void>(null, new HttpHeaders()), Void.class);
         assertEquals(HttpStatus.NOT_FOUND, forEntity.getStatusCode());


### PR DESCRIPTION
Mirror of cloudfoundry uaa#979
Do not check for invalid subdomains in case static content
is requested.

Enables serving of css and images on error page for invalid subdomain.
